### PR TITLE
Removed regex for "clang" in compiler output parsing.

### DIFF
--- a/common/parse_compiler_output.pm
+++ b/common/parse_compiler_output.pm
@@ -108,12 +108,6 @@ sub handle_compiler_output_line($) {
     return;
   }
 
-  if ($s =~ m/clang/)
-  {
-    $self->Output_Normal ($s);
-    return;
-  }
-
   if ($s =~ m/^[ \t]*icl.exe/) {
     $self->Output_Normal ($s);
     return;


### PR DESCRIPTION
clang may appear as part of a directory name, whatever this was trying to do it would need to be a lot more specific.