### PR TITLE
Exit Early for Several Commands When A Child Process Fails

### DIFF
--- a/autobuild.pl
+++ b/autobuild.pl
@@ -37,6 +37,7 @@ my %command_table = ();
 my $cvs_tag;
 my $starting_dir= getcwd ();
 my $warn_nonfatal;
+my $status = 0;
 
 ##############################################################################
 # Load the commands allowed here
@@ -807,6 +808,7 @@ INPFILE: foreach my $file (@files) {
       if ($command_table{$NAME}->Run ($OPTIONS) == 0) {
         print STDERR "ERROR: While $CMD $CMD2:\n" if ($verbose <= 1);
         print STDERR "  The command failed";
+        $status = 1;
         if (!$keep_going) {
           print STDERR ", exiting.\n";
           chdir ($starting_dir);
@@ -829,3 +831,5 @@ INPFILE: foreach my $file (@files) {
   chdir ($starting_dir);
   ChangeENV (%originalENV);
 } ## next input file
+
+exit $status;

--- a/command/anonymous_shell.pm
+++ b/command/anonymous_shell.pm
@@ -9,6 +9,8 @@ use Cwd;
 use FileHandle;
 use File::Path;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -63,11 +65,11 @@ sub Run ($)
 
     print "Running: ${options}\n";
 
-    system ($options);
+    my $status = utility::run_command ($options);
 
     chdir $current_dir;
 
-    return 1;
+    return $status;
 }
 
 ##############################################################################

--- a/command/check_compiler.pm
+++ b/command/check_compiler.pm
@@ -7,6 +7,8 @@ use warnings;
 
 use Cwd;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -45,93 +47,99 @@ sub Run ($)
     print "================ Compiler version ================\n";
 
     if($compiler =~ m/^(\w*-)*(gcc|g\+\+|g\+\+-?[0-9]|ccsimpc|ccpentium|ccppc|c\+\+ppc|c\+\+pentium)/ || $compiler =~ m/^clang(\+\+)?(-[0-9\.]+)?/){
-        system($compiler." -v 2>&1");
-      if($compiler =~ m/^(\w*-)*(gcc|g\+\+|g\+\+-?[0-9])/ || $compiler =~ m/^clang(\+\+)?(-[0-9\.]+)?/){
-          my $linker = `$compiler -print-prog-name=ld`;
-          chomp $linker;
-          if($linker =~ m/ld$/){
-              system($linker." -v 2>&1");
-          }
-          elsif($linker =~ m/ccs/){
-              system($linker." -V 2>&1");
-          }
-      }
+        if (not utility::run_command ($compiler." -v 2>&1")) {
+            return 0;
+        }
+        if($compiler =~ m/^(\w*-)*(gcc|g\+\+|g\+\+-?[0-9])/ || $compiler =~ m/^clang(\+\+)?(-[0-9\.]+)?/){
+            my $linker = `$compiler -print-prog-name=ld`;
+            chomp $linker;
+            if($linker =~ m/ld$/){
+                return utility::run_command ($linker." -v 2>&1");
+            }
+            elsif($linker =~ m/ccs/){
+                return utility::run_command ($linker." -V 2>&1");
+            } else {
+              print STDERR __FILE__, ": ERROR: Unexpected Linker: $linker\n";
+            }
+        }
     }
     elsif(lc $compiler =~ m/^(sun_cc|studio|suncc)/) {
-        system("CC -V");
+        return utility::run_command ("CC -V");
     }
     elsif(lc $compiler eq "mingwcygwin"){
-        system("g++ -v -mno-cygwin");
+        return utility::run_command ("g++ -v -mno-cygwin");
     }
     elsif(lc $compiler eq "bcc32"){
-        system("bcc32 --version");
+        return utility::run_command ("bcc32 --version");
     }
     elsif(lc $compiler eq "bcc32c"){
-        system("bcc32c --version");
+        return utility::run_command ("bcc32c --version");
     }
     elsif(lc $compiler eq "bcc64"){
-        system("bcc64 --version");
+        return utility::run_command ("bcc64 --version");
     }
     elsif(lc $compiler eq "bccx"){
-        system("bccx --version");
+        return utility::run_command ("bccx --version");
     }
     elsif(lc $compiler eq "kylix"){
-        system("bc++ -V");
+        return utility::run_command ("bc++ -V");
     }
     elsif($compiler =~ m/^(dcc|dplus)/){
-        system($compiler . " -V");
+        return utility::run_command ($compiler . " -V");
     }
     elsif(lc $compiler eq "dm"){
-        system("scppn");
+        return utility::run_command ("scppn");
     }
     elsif(lc $compiler =~ m/^(msvc|vc|cl)/){
-        system("cl");
+        return utility::run_command ("cl");
     }
     elsif(lc $compiler eq "deccxx"){
-        system("cxx/VERSION");
+        return utility::run_command ("cxx/VERSION");
     }
     elsif(lc $compiler eq "cxx"){
-        system("cxx -V");
+        return utility::run_command ("cxx -V");
     }
     elsif(lc $compiler eq "acc"){
-        system("aCC -V");
+        return utility::run_command ("aCC -V");
     }
     elsif(lc $compiler eq "pgcc"){
-        system("pgCC -V");
+        return utility::run_command ("pgCC -V");
     }
     elsif(lc $compiler eq "mipspro"){
-        system("CC -version");
+        return utility::run_command ("CC -version");
     }
     elsif(lc $compiler eq "doxygen"){
-        system("doxygen --version");
+        return utility::run_command ("doxygen --version");
     }
     elsif($compiler =~ m/^(ecc|icc|icpc)/){
-        system($compiler." -V 2>&1");
+        return utility::run_command ($compiler." -V 2>&1");
     }
     elsif(lc $compiler eq "icl"){
-        system("icl");
+        return utility::run_command ("icl");
     }
     elsif($compiler =~ m/^(ibmcxx)/i ){
         if(-x "/usr/bin/lslpp"){
-           system("/usr/bin/lslpp -l ibmcxx.cmp | grep ibmcxx.cmp");
-        }else {
-           print "ERROR: Could not find /usr/bin/lslpp!!\n";
+            return utility::run_command ("/usr/bin/lslpp -l ibmcxx.cmp | grep ibmcxx.cmp");
+        } else {
+            print STDERR __FILE__, ": " .
+                "ERROR: Could not find /usr/bin/lslpp!!\n";
         }
     }
     elsif($compiler =~ m/^(vacpp)/i ){
         if(-x "/usr/bin/lslpp"){
-           system("/usr/bin/lslpp -l | grep -i \'C++ Compiler\'");
-        }else {
-           print "ERROR: Could not find /usr/bin/lslpp!!\n";
+            return utility::run_command ("/usr/bin/lslpp -l | grep -i \'C++ Compiler\'");
+        } else {
+            print STDERR __FILE__, ": " .
+                "ERROR: Could not find /usr/bin/lslpp!!\n";
         }
     }
     elsif(lc $compiler eq "c89"){
-        system("c89 -Whelp 2>&1 | tail -2");
+        return utility::run_command ("c89 -Whelp 2>&1 | tail -2");
     }
     else{
-        system($compiler);
+        print STDERR __FILE__, ": " . "Invalid Compiler Option: $compiler\n";
     }
-    return 1;
+    return 0;
 }
 
 ##############################################################################

--- a/command/make.pm
+++ b/command/make.pm
@@ -8,6 +8,8 @@ use warnings;
 use Cwd;
 use File::Path;
 
+using common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -134,7 +136,7 @@ sub Run ($)
 
     my $command;
     my $pattern;
-    my $ret = 0;
+    my $ret;
 
     if ($options =~ s/find=([^\s]*)//) {
         $pattern = $1;
@@ -146,18 +148,17 @@ sub Run ($)
             next unless -f $makefile; # skip directories
             $command = "$make_program -f $makefile $options";
             print "Running: $command\n";
-            $ret = system ($command);
+            $ret = utility::run_command ($command);
         }
     }
     else {
         $options =~ s/'/"/g;
         $command = "$make_program $options";
         print "Running: $command\n";
-        $ret = system ($command);
+        $ret = utility::run_command ($command);
     }
 
-    if( $ret != 0  )
-    {
+    if (!$ret) {
         my $working_dir = getcwd();
 
         ## If we used 'make -C' to change the directory, let's
@@ -168,7 +169,7 @@ sub Run ($)
             $working_dir = "$working_dir/$1";
         }
 
-        print "[BUILD ERROR detected in $working_dir]\n ";
+        print STDERR "[BUILD ERROR detected in $working_dir]\n ";
     }
 
     chdir $current_dir;
@@ -176,7 +177,7 @@ sub Run ($)
     ## Return PWD to the correct setting
     $ENV{PWD} = getcwd();
 
-    return 1;
+    return $ret;
 }
 
 ##############################################################################

--- a/command/shell.pm
+++ b/command/shell.pm
@@ -9,6 +9,8 @@ use Cwd;
 use FileHandle;
 use File::Path;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -65,11 +67,11 @@ sub Run ($)
 
     print "Running: ${options}\n";
 
-    system ($options);
+    my $status = utility::run_command ($options);
 
     chdir $current_dir;
 
-    return 1;
+    return $status;
 }
 
 ##############################################################################

--- a/command/test.pm
+++ b/command/test.pm
@@ -13,6 +13,8 @@ use warnings;
 use Cwd;
 use FileHandle;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -69,11 +71,11 @@ sub Run ($)
 
     print "Running: ${options}\n";
 
-    system ($options);
+    my $status = utility::run_command ($options);
 
     chdir $current_dir;
 
-    return 1;
+    return status;
 }
 
 ##############################################################################

--- a/command/vc6make.pm
+++ b/command/vc6make.pm
@@ -8,6 +8,8 @@ use warnings;
 use Cwd;
 use File::Path;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -86,23 +88,24 @@ sub Run ($)
       $workspace = $1;
     }
 
+    my $ret = 1;
     if (defined $workspace && ! -r $workspace) {
       print "Skipping: $workspace not found\n";
     }
     else {
       print "Running: $command\n";
 
-      my $ret = system ($command);
+      $ret = utility::run_command ($command);
 
-      if ($ret != 0)
+      if (!$ret)
       {
-        print "[BUILD ERROR detected in ", getcwd(), "]\n";
+        print STDERR "[BUILD ERROR detected in ", getcwd(), "]\n";
       }
     }
 
     chdir $current_dir;
 
-    return 1;
+    return $ret;
 }
 
 ##############################################################################

--- a/command/vc7make.pm
+++ b/command/vc7make.pm
@@ -8,6 +8,8 @@ use warnings;
 use Cwd;
 use File::Path;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -105,22 +107,23 @@ sub Run ($)
       $workspace = $1;
     }
 
+    my $ret = 1;
     if (defined $workspace && ! -r $workspace) {
       print "Skipping: $workspace not found\n";
     }
     else {
       print "Running: $command\n";
 
-      my $ret = system ($command);
+      my $ret = utility::run_command ($command);
 
-      if ($ret != 0) {
-        print "[BUILD ERROR detected in ", getcwd(), "]\n";
+      if (!$ret) {
+        print STDERR "[BUILD ERROR detected in ", getcwd(), "]\n";
       }
     }
 
     chdir $current_dir;
 
-    return 1;
+    return $ret;
 }
 
 ##############################################################################

--- a/common/utility.pm
+++ b/common/utility.pm
@@ -1,5 +1,30 @@
+use strict;
 
 package utility;
+
+# Run command, returns 0 if there was an error
+sub run_command ($;$) {
+  my $command = shift;
+  my $ignore_failure = shift;
+  if (!defined $ignore_failure) {
+      $ignore_failure = 0;
+  }
+
+  if (system ($command)) {
+      my $error_message;
+      if ($? == -1) {
+          $error_message = "Failed to Run: $!";
+      } elsif ($? & 127) {
+          $error_message = sprintf ("Exited on Singal %d, %s coredump",
+            ($? & 127),  ($? & 128) ? 'with' : 'without');
+      } else {
+          $error_message = sprintf ("Returned %d", $? >> 8);
+      }
+      print STDERR "Command \"$command\" $error_message\n";
+      return !$ignore_failure;
+  }
+  return 1;
+}
 
 ###############################################################################
 #


### PR DESCRIPTION
Brought up by [OpenDDS#1011](https://github.com/objectcomputing/OpenDDS/pull/1011) where `apt-get install` failed so OpenDDS configure script failed but every single other command was run anyway, even though they were all failures/ I changed several autobuild commands which create child processes to fail when their child processes fail.

Shares some code with #3 .