### PR TITLE
Do not mark the cmake command line that includes _SILENCE_TR1_NAMESPA…

### DIFF
--- a/common/parse_compiler_output.pm
+++ b/common/parse_compiler_output.pm
@@ -578,7 +578,7 @@ sub handle_compiler_output_line($) {
   }
 
   if (($s =~ m/warning/i
-       && ($s !~ m/ warning\(s\)/ && $s !~ m/\-undefined warning/ && $s !~ m/-i[^\s]*warning/i && $s !~ m/-l[^\s]*warning/i && $s !~ m/[^\s]+warning+[^\s]/i) && $s !~ m/0 warnings/)
+       && ($s !~ m/ warning\(s\)/ && $s !~ m/\-undefined warning/ && $s !~ m/-i[^\s]*warning/i && $s !~ m/-l[^\s]*warning/i && $s !~ m/[^\s]+warning+[^\s]/i) && $s !~ m/0 warnings/ && $s !~ m/cmake\s+.*_SILENCE_TR1_NAMESPACE_DEPRECATION_WARNING/)
       || $s =~ m/info: /i
       || $s =~ m/^error \(future\)/i
       || $s =~ m/^.*\.(h|i|inl|hpp|ipp|cpp|java): /)


### PR DESCRIPTION
…CE_DEPRECATION_WARNING as a warning in the build html.