### PR TITLE
auto_run_tests.pm: quotemeta is needed to use strings that can contain characters like "$" as regex patterns

### DIFF
--- a/command/auto_run_tests.pm
+++ b/command/auto_run_tests.pm
@@ -147,11 +147,13 @@ sub Run ($)
       my $script_path;
       if ($options =~ m/script_path='([^']*)'/) {
           $script_path = $1;
-          $options =~ s/script_path='$script_path'//;
+          my $script_pattern = quotemeta $1;
+          $options =~ s/script_path='$script_pattern'//;
       }
       elsif ($options =~ m/script_path=([^\s]*)/) {
           $script_path = $1;
-          $options =~ s/script_path=$script_path//;
+          my $script_pattern = quotemeta $1;
+          $options =~ s/script_path=$script_pattern//;
       }
 
       if (defined $script_path) {


### PR DESCRIPTION
Should fix unintended parameters to auto_run_test.pl in http://buildlogs.remedy.nl/fc_opendds_versioned/index.html