### PR TITLE
Failed Test Brief Log

### DIFF
--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -369,6 +369,7 @@ sub new ($)
     my $self = {};
     my $basename = shift;
     my $buildname = shift;
+    my $rev_link = shift;
 
     my $path = substr($basename, 0, index($basename, '/'));
     my $filename = $path . "/Failed_Tests.html";
@@ -382,6 +383,7 @@ sub new ($)
     $self->{SUBSECTION_COUNTER} = 0;
     $self->{TITLE} = "Failed Test Brief Log";
     $self->{GIT_CHECKEDOUT_OPENDDS} = "unknown";
+    $self->{REV_LINK} = $rev_link;
 
     unless (-e $filename) {
         my $file_handle = new FileHandle ($filename, 'w');
@@ -475,7 +477,7 @@ sub Print_Sections ()
             print {$self->{FH}} "<hr><h2>$self->{BUILDNAME}</h2>\n";
             my $rev = substr($self->{GIT_CHECKEDOUT_OPENDDS}, 0, 8);
             if ($rev ne "unknown") {
-                print {$self->{FH}} "Rev: <a href='https://github.com/objectcomputing/OpenDDS/commit/$rev' >$rev</a><hr>\n";
+                print {$self->{FH}} "Rev: <a href=$self->{REV_LINK}>$rev</a><hr>\n";
             }
             $self->{BUILDNAME} = undef;
         }
@@ -1048,7 +1050,7 @@ use FileHandle;
 
 ###############################################################################
 
-sub new ($$$$)
+sub new ($$$$$)
 {
     my $proto = shift;
     my $class = ref ($proto) || $proto;
@@ -1056,6 +1058,7 @@ sub new ($$$$)
     my $basename = shift;
     my $buildname = shift;
     my $skip_failed_test_logs = shift;
+    my $rev_link = shift;
 
     # Initialize some variables
 
@@ -1087,7 +1090,7 @@ sub new ($$$$)
         );
     
     if (!$skip_failed_test_logs) {
-        push @{$self->{OUTPUT}}, new Prettify::Failed_Tests_HTML ($basename, $buildname); #Must be 4, if used
+        push @{$self->{OUTPUT}}, new Prettify::Failed_Tests_HTML ($basename, $buildname, $rev_link); #Must be 4, if used
     }
 
     my $junit = main::GetVariable ('junit_xml_output');
@@ -1706,15 +1709,16 @@ sub BuildErrors ($)
 # In this function we process the log file line by line,
 # looking for errors.
 
-sub Process ($$$)
+sub Process ($$$$)
 {
     my $filename = shift;
     my $basename = $filename;
     $basename =~ s/\.txt$//;
     my $buildname = shift;
     my $skip_failed_test_logs = shift;
+    my $rev_link = shift;
 
-    my $processor = new Prettify ($basename, $buildname, $skip_failed_test_logs);
+    my $processor = new Prettify ($basename, $buildname, $skip_failed_test_logs, $rev_link);
 
     my $input = new FileHandle ($filename, 'r');
 

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -468,7 +468,8 @@ sub Print_Sections ()
     if (defined $self->{LAST_SECTION} && defined $self->{LAST_SUBSECTION} && $self->{LAST_SECTION} eq 'Test') {
         if (defined $self->{BUILDNAME}) {
             print {$self->{FH}} "<hr><h2>$self->{BUILDNAME}</h2>\n";
-            print {$self->{FH}} "Rev: $self->{GIT_CHECKEDOUT_OPENDDS}<hr>\n";
+            my $rev = substr($self->{GIT_CHECKEDOUT_OPENDDS}, 0, 8);
+            print {$self->{FH}} "Rev: $rev<hr>\n";
             $self->{BUILDNAME} = undef;
         }
 

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -484,18 +484,21 @@ sub Error ($)
     my $self = shift;
     my $s = shift;
 
-    # Escape any '<' or '>' signs
-    $s =~ s/</&lt;/g;
-    $s =~ s/>/&gt;/g;
+    if (defined $self->{LAST_SECTION} && $self->{LAST_SECTION} eq 'Test') {
 
-    my $counter = ++$self->{ERROR_COUNTER};
+        # Escape any '<' or '>' signs
+        $s =~ s/</&lt;/g;
+        $s =~ s/>/&gt;/g;
 
-    $self->Print_Sections ();
+        my $counter = ++$self->{ERROR_COUNTER};
 
-    print {$self->{FH}} "<a name=\"error_$counter\"></a>\n";
-    print {$self->{FH}} "<tt>[<a href=\"$self->{FULLHTML}#error_$counter"
-                        . "\">Details</a>] </tt>";
-    print {$self->{FH}} "<font color=\"FF0000\"><tt>$s</tt></font><br>\n";
+        $self->Print_Sections ();
+
+        print {$self->{FH}} "<a name=\"error_$counter\"></a>\n";
+        print {$self->{FH}} "<tt>[<a href=\"$self->{FULLHTML}#error_$counter"
+                            . "\">Details</a>] </tt>";
+        print {$self->{FH}} "<font color=\"FF0000\"><tt>$s</tt></font><br>\n";
+    }
 }
 
 sub Warning ($)
@@ -503,18 +506,20 @@ sub Warning ($)
     my $self = shift;
     my $s = shift;
 
-    # Escape any '<' or '>' signs
-    $s =~ s/</&lt;/g;
-    $s =~ s/>/&gt;/g;
+    if (defined $self->{LAST_SECTION} && $self->{LAST_SECTION} eq 'Test') {
+        # Escape any '<' or '>' signs
+        $s =~ s/</&lt;/g;
+        $s =~ s/>/&gt;/g;
 
-    my $counter = ++$self->{WARNING_COUNTER};
+        my $counter = ++$self->{WARNING_COUNTER};
 
-    $self->Print_Sections ();
+        $self->Print_Sections ();
 
-    print {$self->{FH}} "<a name=\"warning_$counter\"></a>\n";
-    print {$self->{FH}} "<tt>[<a href=\"$self->{FULLHTML}#warning_$counter"
-                        . "\">Details</a>] </tt>";
-    print {$self->{FH}} "<font color=\"FF7700\"><tt>$s</tt></font><br>\n";
+        print {$self->{FH}} "<a name=\"warning_$counter\"></a>\n";
+        print {$self->{FH}} "<tt>[<a href=\"$self->{FULLHTML}#warning_$counter"
+                            . "\">Details</a>] </tt>";
+        print {$self->{FH}} "<font color=\"FF7700\"><tt>$s</tt></font><br>\n";
+    }
 }
 
 sub Normal ($)

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -399,21 +399,26 @@ sub new ($)
 sub Header ()
 {
     my $self = shift;
-    print {$self->{FH}} "<html>\n";
-    print {$self->{FH}} "<body bgcolor=\"white\">\n";
+
+    if (defined $self->{LAST_SECTION} && $self->{LAST_SECTION} eq 'Test') {
+        print {$self->{FH}} "<html>\n";
+        print {$self->{FH}} "<body bgcolor=\"white\">\n";
+    }
 }
 
 sub Footer ()
 {
     my $self = shift;
 
-    # In the case where there was no errors or warnings, output a note
-    if ($self->{ERROR_COUNTER} == 0 && $self->{WARNING_COUNTER} == 0) {
-        print {$self->{FH}} "No Errors or Warnings detected<br>\n";
-    }
+    if (defined $self->{LAST_SECTION} && $self->{LAST_SECTION} eq 'Test') {
+        # In the case where there was no errors or warnings, output a note
+        if ($self->{ERROR_COUNTER} == 0 && $self->{WARNING_COUNTER} == 0) {
+            print {$self->{FH}} "No Errors or Warnings detected<br>\n";
+        }
 
-    print {$self->{FH}} "</body>\n";
-    print {$self->{FH}} "</html>\n";
+        print {$self->{FH}} "</body>\n";
+        print {$self->{FH}} "</html>\n";
+    }
 }
 
 sub Section ($)

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -474,7 +474,9 @@ sub Print_Sections ()
         if (defined $self->{BUILDNAME}) {
             print {$self->{FH}} "<hr><h2>$self->{BUILDNAME}</h2>\n";
             my $rev = substr($self->{GIT_CHECKEDOUT_OPENDDS}, 0, 8);
-            print {$self->{FH}} "Rev: $rev<hr>\n";
+            if ($rev ne "unknown") {
+                print {$self->{FH}} "Rev: <a href='https://github.com/objectcomputing/OpenDDS/commit/$rev' >$rev</a><hr>\n";
+            }
             $self->{BUILDNAME} = undef;
         }
 

--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -151,6 +151,7 @@ sub build_index_page ($$)
 
     ### Print timestamp
 
+    print $indexhtml "<br><a href=\"Failed_Tests.html\">Failed Test Brief Log</a><br>\n";
     print $indexhtml '<br>Last updated at ' . get_time_str() . "<br>\n";
 
     ### Print the Footer
@@ -1138,6 +1139,7 @@ sub update_html ($$$)
 
     ### Print timestamp
 
+    print $indexhtml "<br><a href=\"Failed_Tests.html\">Failed Test Brief Log</a><br>\n";
     print $indexhtml '<br>Last updated at ' . get_time_str() . "<br>\n";
 
     ### Print the Footer

--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -540,7 +540,27 @@ sub update_cache ($)
                 }
 
                 print "        Prettifying\n" if($verbose);
-                Prettify::Process ("$directory/$buildname/$filename", $buildname, $use_build_logs);
+
+                my $diffRev = '';
+                if (defined $builds{$buildname}->{SUBVERSION_CHECKEDOUT_OPENDDS} &&
+                    !($builds{$buildname}->{SUBVERSION_CHECKEDOUT_OPENDDS} =~ /None/)) {
+                    $diffRev = $builds{$buildname}->{SUBVERSION_CHECKEDOUT_OPENDDS};
+                }
+                else {
+                    $diffRev = 'None';
+                }
+                my $diffRoot = $builds{$buildname}->{DIFFROOT};
+                my $link = '';
+                my $linktarget = '';
+                if (defined $main::opt_n) {
+                    $linktarget = "target=\"_blank\""
+                }
+                # If we have a diff revision, and a diffroot URL, create a link
+                if (($diffRev !~ /None/) && ($diffRoot)) {
+                  my $url = $diffRoot . $diffRev;
+                  $link = "<a href='$url' $linktarget>$diffRev</a>";
+                }
+                Prettify::Process ("$directory/$buildname/$filename", $buildname, $use_build_logs, $link);
             }
         }
     }
@@ -659,7 +679,28 @@ sub local_update_cache ($)
             if ( -e $file . "_Totals.html" ) {next;}
             if ( $post == 1 ) {
                 print "        Prettifying $file.txt\n" if($verbose);
-                Prettify::Process ("$file.txt", $buildname, $use_build_logs);
+
+                my $diffRev = '';
+                if (defined $builds{$buildname}->{SUBVERSION_CHECKEDOUT_OPENDDS} &&
+                    !($builds{$buildname}->{SUBVERSION_CHECKEDOUT_OPENDDS} =~ /None/)) {
+                    $diffRev = $builds{$buildname}->{SUBVERSION_CHECKEDOUT_OPENDDS};
+                }
+                else {
+                    $diffRev = 'None';
+                }
+                my $diffRoot = $builds{$buildname}->{DIFFROOT};
+                my $link = '';
+                my $linktarget = '';
+                if (defined $main::opt_n) {
+                    $linktarget = "target=\"_blank\""
+                }
+                # If we have a diff revision, and a diffroot URL, create a link
+                if (($diffRev !~ /None/) && ($diffRoot)) {
+                  my $url = $diffRoot . $diffRev;
+                  $link = "<a href='$url' $linktarget>$diffRev</a>";
+                }
+
+                Prettify::Process ("$file.txt", $buildname, $use_build_logs, $link);
                 $updated++;
             } else {
                 # Create the triggerfile for the next time we run

--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -539,7 +539,7 @@ sub update_cache ($)
                 }
 
                 print "        Prettifying\n" if($verbose);
-                Prettify::Process ("$directory/$buildname/$filename");
+                Prettify::Process ("$directory/$buildname/$filename", $buildname);
             }
         }
     }
@@ -653,7 +653,7 @@ sub local_update_cache ($)
             if ( -e $file . "_Totals.html" ) {next;}
             if ( $post == 1 ) {
                 print "        Prettifying $file.txt\n" if($verbose);
-                Prettify::Process ("$file.txt");
+                Prettify::Process ("$file.txt", $buildname);
                 $updated++;
             } else {
                 # Create the triggerfile for the next time we run

--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -540,7 +540,7 @@ sub update_cache ($)
                 }
 
                 print "        Prettifying\n" if($verbose);
-                Prettify::Process ("$directory/$buildname/$filename", $buildname);
+                Prettify::Process ("$directory/$buildname/$filename", $buildname, $use_build_logs);
             }
         }
     }
@@ -659,7 +659,7 @@ sub local_update_cache ($)
             if ( -e $file . "_Totals.html" ) {next;}
             if ( $post == 1 ) {
                 print "        Prettifying $file.txt\n" if($verbose);
-                Prettify::Process ("$file.txt", $buildname);
+                Prettify::Process ("$file.txt", $buildname, $use_build_logs);
                 $updated++;
             } else {
                 # Create the triggerfile for the next time we run
@@ -1149,7 +1149,9 @@ sub update_html ($$$)
 
     ### Print timestamp
 
-    print $indexhtml "<br><a href=\"Failed_Tests.html\">Failed Test Brief Log</a><br>\n";
+    if (!$use_build_logs) {
+        print $indexhtml "<br><a href=\"Failed_Tests.html\">Failed Test Brief Log</a><br>\n";
+    }
     print $indexhtml '<br>Last updated at ' . get_time_str() . "<br>\n";
 
     ### Print the Footer

--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -568,6 +568,11 @@ sub local_update_cache ($)
         return;
     }
 
+    my $failed_tests = $directory . "/Failed_Tests.html";
+    if (-e $failed_tests) {
+        unlink $failed_tests;
+    }
+
     foreach my $buildname (keys %builds) {
         my $keep = $keep_default;
         my @existing;
@@ -780,6 +785,11 @@ sub clean_cache ($)
         return;
     }
 
+    my $failed_tests = $directory . "/Failed_Tests.html";
+    if (-e $failed_tests) {
+        unlink $failed_tests;
+    }
+
     foreach my $buildname (keys %builds) {
         ### Do we use the local cache or do we work
         ### with the storage of the build itself?
@@ -828,11 +838,6 @@ sub clean_cache ($)
                 unlink $file . "_Config.html";
             }
         }
-    }
-
-    my $failed_tests = $directory . "/Failed_Tests.html";
-    if (-e $failed_tests) {
-        unlink $failed_tests;
     }
 }
 

--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -829,6 +829,11 @@ sub clean_cache ($)
             }
         }
     }
+
+    my $failed_tests = $directory . "/Failed_Tests.html";
+    if (-e $failed_tests) {
+        unlink $failed_tests;
+    }
 }
 
 sub numerically { $a <=> $b }


### PR DESCRIPTION
Need the ability to quickly look at the output for failing tests to determine the root cause.

This view lists all of the platforms containing a failing test.
Consolidates information found across platforms as seen in the Brief view under Tests 