### PR TITLE
Allow `cmake` Command to Fail Non-Fatally

### DIFF
--- a/command/cmake.pm
+++ b/command/cmake.pm
@@ -52,6 +52,10 @@ sub Run ($)
 
     my $command_name = $self->{simple} ? "cmake_cmd" : "cmake";
 
+    main::PrintStatus (
+      ($self->{simple} && $options !~ /\W--build\W/) ? 'Configure' : 'Compile',
+      $command_name);
+
     # Get cmake_var_* Autobuild Variables
     my @cmake_vars = ();
     my $autobuild_var_cmake_var_re = qr/^cmake_var_(\w+)$/;

--- a/command/cmake.pm
+++ b/command/cmake.pm
@@ -93,7 +93,7 @@ sub Run ($)
         else {
             print STDERR __FILE__,
                 ": unexpected arg name \"$name\" in $command_name command\n";
-            return 0;
+            return {failure => 'fatal'};
         }
     }
 
@@ -104,14 +104,17 @@ sub Run ($)
         $config_args .= " -G \"$cmake_generator\"";
     }
 
+    my $result = {};
+
     # cmake_cmd commmand
     if ($self->{simple}) {
-        return utility::run_command ("$cmake_command $options");
+        utility::run_command ("$cmake_command $options", $result);
+        return $result;
     }
     elsif (length ($options)) {
         print STDERR __FILE__,
             ": options attribute not allowed for the cmake command\n";
-        return 0;
+        return {failure => 'fatal'};
     }
 
     # Insert cmake_var_* Autobuild Variables and var_* Arguments
@@ -124,28 +127,28 @@ sub Run ($)
 
     # Recreate Build Directory
     if (!utility::remove_tree ($build_dir)) {
-        return 0;
+        return {failure => 'fatal'};
     }
     if (!mkdir ($build_dir)) {
         print STDERR __FILE__, ": failed to make build directory \"$build_dir\": $!\n";
-        return 0;
+        return {failure => 'fatal'};
     }
 
     # Change to Build Directory
     my $build_cd = ChangeDir->new({dir => $build_dir});
-    return 0 unless ($build_cd);
+    return {'failure' => 'fatal'} unless ($build_cd);
 
     # Run Configure CMake Command
-    if (!utility::run_command ("$cmake_command $config_args")) {
-        return 0;
+    if (!utility::run_command ("$cmake_command $config_args", $result)) {
+        return $result;
     }
 
     # Run Build CMake Command
-    if (!utility::run_command ("$cmake_command $build_args")) {
-        return 0;
+    if (!utility::run_command ("$cmake_command $build_args", $result)) {
+        return $result;
     }
 
-    return 1;
+    return $result;
 }
 
 ##############################################################################

--- a/command/cmake.pm
+++ b/command/cmake.pm
@@ -140,7 +140,7 @@ sub Run ($)
 
     # Change to Build Directory
     my $build_cd = ChangeDir->new({dir => $build_dir});
-    return {'failure' => 'fatal'} unless ($build_cd);
+    return {failure => 'fatal'} unless ($build_cd);
 
     # Run Configure CMake Command
     if (!utility::run_command ("$cmake_command $config_args", $result)) {

--- a/command/print_cmake_version.pm
+++ b/command/print_cmake_version.pm
@@ -46,9 +46,7 @@ sub Run ($)
     my $cmake_command = main::GetVariable ('cmake_command');
     $cmake_command = "\"$cmake_command\" --version";
 
-    main::PrintStatus ('Config', "print CMake Version");
-
-    print "<h3>CMake version ($cmake_command)</h3>\n";
+    main::PrintStatus ('Config', "CMake Version ($cmake_command)");
 
     return utility::run_command ($cmake_command);
 }

--- a/tests/autobuild/cmake/fake_cmake.pl
+++ b/tests/autobuild/cmake/fake_cmake.pl
@@ -10,6 +10,10 @@ if ($args eq "<<--version>>") {
     print ("fake_cmake.pl version 123.456.789\n");
 }
 
+if ($args =~ "<<--fail-on-purpose>>") {
+    exit (1);
+}
+
 my $file = "cmake_runs.txt";
 open (my $fd, ">>$file") or die ("Couldn't open $file: $!");
 print $fd "$args\n";

--- a/tests/autobuild/cmake/run_test.pl
+++ b/tests/autobuild/cmake/run_test.pl
@@ -50,6 +50,10 @@ expect_file_contents (
     "build/cmake_runs.txt");
 
 expect_file_contents (
+    "<<..>> <<-G>> <<Fake Generator>> <<-DCMAKE_C_COMPILER=fake-cc>>\n",
+    "failed_build/cmake_runs.txt");
+
+expect_file_contents (
     "<<..>> <<-G>> <<Fake Generator>> " .
       "<<-DCMAKE_C_COMPILER=super-fake-cc>> " .
       "<<-DCMAKE_CXX_COMPILER=super-fake-c++>>\n" .

--- a/tests/autobuild/cmake/test.xml
+++ b/tests/autobuild/cmake/test.xml
@@ -16,6 +16,12 @@
   <!-- All Defaults -->
   <command name="cmake"/>
 
+  <!-- CMake command can fail without bringing down autobuild -->
+  <command name="cmake">
+    <arg name="build_dir">failed_build</arg>
+    <arg name="add_build_args">--fail-on-purpose</arg>
+  </command>
+
   <!-- Override a cmake_var_ -->
   <command name="cmake" dir="subdir1">
     <arg name="var_CMAKE_C_COMPILER">super-fake-cc</arg>

--- a/tests/autobuild/cmake/test.xml
+++ b/tests/autobuild/cmake/test.xml
@@ -11,7 +11,6 @@
 
   <command name="log" options="on"/>
   <command name="print_cmake_version"/>
-  <command name="log" options="off"/>
 
   <!-- All Defaults -->
   <command name="cmake"/>
@@ -38,4 +37,5 @@
   </command>
 
   <command name="cmake_cmd" options="--cmake-cmd"/>
+  <command name="log" options="off"/>
 </autobuild>


### PR DESCRIPTION
Created a new command error return mechanism that distinguishes between fatal and non-fatal errors. This is indented to work with the `required` attribute from https://github.com/DOCGroup/autobuild/pull/4.

Also set status for `cmake` command so it falls under the "Compile" Sections.