### PR TITLE
Add print_openssl_version to build steps.

### DIFF
--- a/configs/autobuild/microfocus/common_start.xml
+++ b/configs/autobuild/microfocus/common_start.xml
@@ -26,6 +26,7 @@
     <command name="print_ace_config" />
     <command name="print_make_version" />
     <command name="print_perl_version" />
+    <command name="print_openssl_version" />
 
     <command name="shell" options="ps -ef | grep <root> | grep -v grep" />
     <command name="shell" options="ps -ef | grep <root> | grep -v grep | awk '{print $2}' | xargs kill" />


### PR DESCRIPTION
Add print_openssl_version as requested by @mitza-oci hopefully better late than never.