### PR TITLE
Fix for autobuild broken on Perl v5.8

### DIFF
--- a/autobuild.pl
+++ b/autobuild.pl
@@ -264,11 +264,13 @@ sub GetVariablesMatching ($)
 
 ##############################################################################
 #
-sub SetVariable ($$;$)
+sub SetVariable
 {
   my $name = shift;
   my $value = shift;
-  my $our_data = shift // \%data;
+  my $our_data = shift;
+
+  $our_data = \%data if ! defined $our_data;
 
   my @new_vars_order = grep {$_ ne $name} @{$our_data->{vars_order}};
   if (defined ($value)) {

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -17,9 +17,10 @@ our $path = "";
 sub new ($)
 {
     my $proto = shift;
+    my $basename = shift;
+
     my $class = ref ($proto) || $proto;
     my $self = {};
-    my $basename = shift;
     my $filename = $basename . "_Full.html";
     my $log_root = main::GetVariable('log_root');
     $path = ((defined $log_root) ? ($log_root . '/' . $filename) : $filename);
@@ -39,7 +40,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ()
+sub Header ($)
 {
     my $self = shift;
     print {$self->{FH}} "<html>\n";
@@ -48,7 +49,7 @@ sub Header ()
     print {$self->{FH}} "<h1>Daily Build Log</h1>\n";
 }
 
-sub Footer ()
+sub Footer ($)
 {
     my $self = shift;
     print {$self->{FH}} "</body>\n";
@@ -206,9 +207,10 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
+    my $basename = shift;
+
     my $class = ref ($proto) || $proto;
     my $self = {};
-    my $basename = shift;
     my $filename = $basename . "_Brief.html";
 
     $basename =~ s/^.*\///;
@@ -225,7 +227,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ()
+sub Header ($)
 {
     my $self = shift;
     print {$self->{FH}} "<html>\n";
@@ -234,7 +236,7 @@ sub Header ()
     print {$self->{FH}} "<h1>Daily Build Log (Brief)</h1>\n";
 }
 
-sub Footer ()
+sub Footer ($)
 {
     my $self = shift;
 
@@ -368,13 +370,14 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
-    my $class = ref ($proto) || $proto;
-    my $self = {};
     my $basename = shift;
     my $buildname = shift;
     my $failed_tests = shift;
     my $rev_link = shift;
     my $log_prefix = shift;
+
+    my $class = ref ($proto) || $proto;
+    my $self = {};
 
     my $filename = $log_prefix . "_Failed_Tests_By_Build.html";
 
@@ -595,10 +598,11 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
+    my $basename = shift;
+
     my $class = ref ($proto) || $proto;
     my $self = {};
 
-    my $basename = shift;
     my $filename = $basename . '_JUnit.xml';
     $self->{FH} = new FileHandle ($filename, 'w');
     $self->{FILENAME} = $filename;
@@ -610,7 +614,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ()
+sub Header ($)
 {
     my $self = shift;
     my $out = $self->{FH};
@@ -619,7 +623,7 @@ sub Header ()
       '            xsi:noNamespaceSchemaLocation="JUnit.xsd">', "\n";
 }
 
-sub Footer ()
+sub Footer ($)
 {
     my $self = shift;
     my $out = $self->{FH};
@@ -732,7 +736,9 @@ sub CleanCData
 sub Error ($)
 {
     my $self = shift;
-    my $line = (shift) . "\n";
+    my $line = shift;
+
+    $line = $line .  "\n";
     my $test = $self->CurrentTest ();
     return unless defined $test;
 
@@ -745,7 +751,9 @@ sub Error ($)
 sub Warning ($)
 {
     my $self = shift;
-    my $line = (shift) . "\n";
+    my $line = shift;
+
+    $line = $line .  "\n";
     my $test = $self->CurrentTest ();
     return unless defined $test;
     CleanCData (\$line);
@@ -755,7 +763,9 @@ sub Warning ($)
 sub Normal ($)
 {
     my $self = shift;
-    my $line = (shift) . "\n";
+    my $line = shift;
+
+    $line = $line .  "\n";
     my $test = $self->CurrentTest ();
     return unless defined $test;
     my $separator = '=' x 78 . "\n";
@@ -789,8 +799,8 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
-    my $class = ref ($proto) || $proto;
     my $basename = shift;
+    my $class = ref ($proto) || $proto;
     my $filename = $basename . '_Totals.html';
     my $self = {};
 
@@ -1937,9 +1947,9 @@ my $host_next = 0;
 sub new ($)
 {
     my $proto = shift;
+    my $basename = shift;
     my $class = ref ($proto) || $proto;
     my $self = {};
-    my $basename = shift;
     my $filename = $basename . "_Config.html";
 
     $basename =~ s/^.*\///;
@@ -1956,7 +1966,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ()
+sub Header ($)
 {
     my $self = shift;
     print {$self->{FH}} "<html>\n";
@@ -1966,7 +1976,7 @@ sub Header ()
     print {$self->{FH}} "<pre>\n";
 }
 
-sub Footer ()
+sub Footer ($)
 {
     my $self = shift;
     print {$self->{FH}} "</pre>\n";

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -17,10 +17,9 @@ our $path = "";
 sub new ($)
 {
     my $proto = shift;
-    my $basename = shift;
-
     my $class = ref ($proto) || $proto;
     my $self = {};
+    my $basename = shift;
     my $filename = $basename . "_Full.html";
     my $log_root = main::GetVariable('log_root');
     $path = ((defined $log_root) ? ($log_root . '/' . $filename) : $filename);
@@ -40,7 +39,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ($)
+sub Header ()
 {
     my $self = shift;
     print {$self->{FH}} "<html>\n";
@@ -49,7 +48,7 @@ sub Header ($)
     print {$self->{FH}} "<h1>Daily Build Log</h1>\n";
 }
 
-sub Footer ($)
+sub Footer ()
 {
     my $self = shift;
     print {$self->{FH}} "</body>\n";
@@ -207,10 +206,9 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
-    my $basename = shift;
-
     my $class = ref ($proto) || $proto;
     my $self = {};
+    my $basename = shift;
     my $filename = $basename . "_Brief.html";
 
     $basename =~ s/^.*\///;
@@ -227,7 +225,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ($)
+sub Header ()
 {
     my $self = shift;
     print {$self->{FH}} "<html>\n";
@@ -236,7 +234,7 @@ sub Header ($)
     print {$self->{FH}} "<h1>Daily Build Log (Brief)</h1>\n";
 }
 
-sub Footer ($)
+sub Footer ()
 {
     my $self = shift;
 
@@ -370,14 +368,13 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
+    my $class = ref ($proto) || $proto;
+    my $self = {};
     my $basename = shift;
     my $buildname = shift;
     my $failed_tests = shift;
     my $rev_link = shift;
     my $log_prefix = shift;
-
-    my $class = ref ($proto) || $proto;
-    my $self = {};
 
     my $filename = $log_prefix . "_Failed_Tests_By_Build.html";
 
@@ -598,11 +595,10 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
-    my $basename = shift;
-
     my $class = ref ($proto) || $proto;
     my $self = {};
 
+    my $basename = shift;
     my $filename = $basename . '_JUnit.xml';
     $self->{FH} = new FileHandle ($filename, 'w');
     $self->{FILENAME} = $filename;
@@ -614,7 +610,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ($)
+sub Header ()
 {
     my $self = shift;
     my $out = $self->{FH};
@@ -623,7 +619,7 @@ sub Header ($)
       '            xsi:noNamespaceSchemaLocation="JUnit.xsd">', "\n";
 }
 
-sub Footer ($)
+sub Footer ()
 {
     my $self = shift;
     my $out = $self->{FH};
@@ -736,9 +732,7 @@ sub CleanCData
 sub Error ($)
 {
     my $self = shift;
-    my $line = shift;
-
-    $line = $line .  "\n";
+    my $line = (shift) . "\n";
     my $test = $self->CurrentTest ();
     return unless defined $test;
 
@@ -751,9 +745,7 @@ sub Error ($)
 sub Warning ($)
 {
     my $self = shift;
-    my $line = shift;
-
-    $line = $line .  "\n";
+    my $line = (shift) . "\n";
     my $test = $self->CurrentTest ();
     return unless defined $test;
     CleanCData (\$line);
@@ -763,9 +755,7 @@ sub Warning ($)
 sub Normal ($)
 {
     my $self = shift;
-    my $line = shift;
-
-    $line = $line .  "\n";
+    my $line = (shift) . "\n";
     my $test = $self->CurrentTest ();
     return unless defined $test;
     my $separator = '=' x 78 . "\n";
@@ -799,8 +789,8 @@ use FileHandle;
 sub new ($)
 {
     my $proto = shift;
-    my $basename = shift;
     my $class = ref ($proto) || $proto;
+    my $basename = shift;
     my $filename = $basename . '_Totals.html';
     my $self = {};
 
@@ -1955,9 +1945,9 @@ my $host_next = 0;
 sub new ($)
 {
     my $proto = shift;
-    my $basename = shift;
     my $class = ref ($proto) || $proto;
     my $self = {};
+    my $basename = shift;
     my $filename = $basename . "_Config.html";
 
     $basename =~ s/^.*\///;
@@ -1974,7 +1964,7 @@ sub new ($)
     return $self;
 }
 
-sub Header ($)
+sub Header ()
 {
     my $self = shift;
     print {$self->{FH}} "<html>\n";
@@ -1984,7 +1974,7 @@ sub Header ($)
     print {$self->{FH}} "<pre>\n";
 }
 
-sub Footer ($)
+sub Footer ()
 {
     my $self = shift;
     print {$self->{FH}} "</pre>\n";

--- a/common/prettify.pm
+++ b/common/prettify.pm
@@ -1811,17 +1811,25 @@ sub BuildErrors ($)
 # In this function we process the log file line by line,
 # looking for errors.
 
-sub Process ($;$$$$$$)
+sub Process
 {
     my $filename = shift;
+    my $buildname = shift;
+    my $failed_tests_ref = shift;
+    my $skip_failed_test_logs = shift;
+    my $rev_link = shift;
+    my $log_prefix = shift;
+    my $failed_tests_only = shift;
+
+    $buildname = "" if ! defined $buildname;
+    $failed_tests_ref = {} if ! defined $failed_tests_ref;
+    $skip_failed_test_logs = 1 if ! defined $skip_failed_test_logs;
+    $rev_link = "" if ! defined $rev_link;
+    $log_prefix = "" if ! defined $log_prefix;
+    $failed_tests_only = 0 if ! defined $failed_tests_only;
+
     my $basename = $filename;
     $basename =~ s/\.txt$//;
-    my $buildname = shift // "";
-    my $failed_tests_ref = shift // {};
-    my $skip_failed_test_logs = shift // 1;
-    my $rev_link = shift // "";
-    my $log_prefix = shift // "";
-    my $failed_tests_only = shift // 0;
 
     my $processor = new Prettify ($basename, $buildname, $failed_tests_ref, $skip_failed_test_logs, $rev_link, $log_prefix, $failed_tests_only);
 


### PR DESCRIPTION
This change puts autobuild back into a working state if your Perl is old. A lot of our LTS stuff builds or tests (with autobuild) on pretty old kit. A series of changes in Feb earlier this year introduced some syntax that I guess is too modern.

The Perl error looked like:

```
-bash-3.00$ cat doc_group_build.log 
Warning: Use of "shift" without parentheses is ambiguous at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1719 (#1)
    (S ambiguous) You wrote a unary operator followed by something that
    looks like a binary operator that could also have been interpreted as a
    term or unary operator.  For instance, if you know that the rand
    function has a default argument of 1.0, and you write
    
        rand + 5;
    
    you may THINK you wrote the same thing as
    
        rand() + 5;
    
    but in actual fact, you got
    
        rand(+5);
    
    So put in parentheses to say what you really mean.
    
String found where operator expected at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1719, near "// """ (#2)
    (S syntax) The Perl lexer knows whether to expect a term or an operator.
    If it sees what it knows to be a term when it was expecting to see an
    operator, it gives you this warning.  Usually it indicates that an
    operator or delimiter was omitted, such as a semicolon.
    
        (Missing operator before  ""?)
Warning: Use of "shift" without parentheses is ambiguous at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1720 (#1)
Number found where operator expected at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1720, near "// 1" (#2)
        (Missing operator before  1?)
Warning: Use of "shift" without parentheses is ambiguous at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1721 (#1)
String found where operator expected at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1721, near "// """ (#2)
        (Missing operator before  ""?)
Warning: Use of "shift" without parentheses is ambiguous at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1722 (#1)
String found where operator expected at
        /home/oftao/docgit/autobuild/common/prettify.pm line 1722, near "// """ (#2)
        (Missing operator before  ""?)

syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1719, near "// """
syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1720, near "// 1"
syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1721, near "// """
syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1722, near "// """
BEGIN not safe after errors--compilation aborted at /home/oftao/docgit/autobuild/common/prettify.pm line 1839.
Compilation failed in require at /home/oftao/docgit/autobuild/command/notify.pm line 13.
BEGIN failed--compilation aborted at /home/oftao/docgit/autobuild/command/notify.pm line 13.
Compilation failed in require at /home/oftao/docgit/autobuild//autobuild.pl line 73 (#3)
    (F) Probably means you had a syntax error.  Common reasons include:
    
        A keyword is misspelled.
        A semicolon is missing.
        A comma is missing.
        An opening or closing parenthesis is missing.
        An opening or closing brace is missing.
        A closing quote is missing.
    
    Often there will be another error message associated with the syntax
    error giving more information.  (Sometimes it helps to turn on -w.)
    The error message itself often tells you where it was in the line when
    it decided to give up.  Sometimes the actual error is several tokens
    before this, because Perl is good at understanding random input.
    Occasionally the line number may be misleading, and once in a blue moon
    the only way to figure out what's triggering the error is to call
    perl -c repeatedly, chopping away half the program each time to see
    if the error went away.  Sort of the cybernetic version of S<20
    questions>.
    
Uncaught exception from user code:
        syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1719, near "// """
syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1720, near "// 1"
syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1721, near "// """
syntax error at /home/oftao/docgit/autobuild/common/prettify.pm line 1722, near "// """
BEGIN not safe after errors--compilation aborted at /home/oftao/docgit/autobuild/common/prettify.pm line 1839.
Compilation failed in require at /home/oftao/docgit/autobuild/command/notify.pm line 13.
BEGIN failed--compilation aborted at /home/oftao/docgit/autobuild/command/notify.pm line 13.
Compilation failed in require at /home/oftao/docgit/autobuild//autobuild.pl line 73.
```