### PR TITLE
Fixes Related to The Test Matrix

### DIFF
--- a/scoreboard.pl
+++ b/scoreboard.pl
@@ -324,7 +324,7 @@ sub build_index_page ($$)
     print "Generating index page\n" if ($verbose);
 
     unless ($indexhtml->open (">$filename")) {
-        warn 'Could not create file: '.$filename." ".$_;
+        warn "Could not create index page file $filename: $!";
         return;
     }
 
@@ -858,6 +858,7 @@ sub clean_cache ($)
             foreach my $file (@existing) {
                 print "        Removing $file files\n" if ($verbose);
                 unlink $file . ".txt";
+                unlink $file . ".build.json";
                 unlink $file . "_Full.html";
                 unlink $file . "_Brief.html";
                 unlink $file . "_Totals.html";
@@ -1837,7 +1838,6 @@ if (defined $opt_l) {
 
 if (defined $opt_i){
     $index = $opt_i;
-    load_build_list ($inp_file);
     print 'Running Index Page Update at ' . get_time_str() . "\n" if ($verbose);
     build_index_page ($dir, $index);
     exit (0);

--- a/testmatrix/HTMLScoreboard.py
+++ b/testmatrix/HTMLScoreboard.py
@@ -178,6 +178,7 @@ class HtmlTable:
 
 
 def get_build_details_path(build, basename):
+    build.dir.mkdir(parents=True, exist_ok=True)
     return build.dir / f'{basename}-build-details.html'
 
 

--- a/testmatrix/matrix.css
+++ b/testmatrix/matrix.css
@@ -59,7 +59,6 @@ table.test_results td[test] a {
 td.test_name {
     font-family: monospace;
     text-align: left;
-    overflow-x: scroll;
     white-space: nowrap;
 }
 td.txt {text-align: left;}


### PR DESCRIPTION
Fixes for #74

- `scoreboard.pl`:
    - Removed what looks like an unused function call to fix #75.
    - Fix a warning message
    - Clean up `*.build.json` files.
- `matrix.py`:
    - Fixed an issue on Chromium browsers where the test names would always get a scroll bar that would about double the size of the rows and impacted the usability of the matrix. Mainly tested with Firefox which doesn't have this problem. Removed explicit `overflow-x: scroll`CSS property to fix this.
      - Before:
        ![Screenshot from 2025-01-17 19-38-15](https://github.com/user-attachments/assets/497b317f-170b-4b10-96f8-1198ab8019cd)
      - After:
        ![Screenshot from 2025-01-17 19-38-38](https://github.com/user-attachments/assets/df6d3654-f6ff-41f3-bd79-9da463c9c1bd)
    - Fixes so ACE/TAO scoreboard can use the test matrix:
        - Remove dependency on `scoreboard.pl -c` option, which creates the build directories and downloads the `*.build.json` files for us. OpenDDS uses `-c`, but ACE/TAO doesn't.
        - Fix a Python Type error for average test time when a matrix is empty. This is the case for ACE6 builds at the moment.