### PR TITLE
Try to Fix Issues in ACE/TAO Scoreboard

### DIFF
--- a/common/integratedparser.pm
+++ b/common/integratedparser.pm
@@ -6,6 +6,8 @@ use warnings;
 
 use FileHandle;
 
+use common::utility;
+
 ###############################################################################
 # Constructor
 
@@ -95,6 +97,8 @@ sub Parse ($\@)
                 # Make the global name null
                 $global_build_name = '';
             }
+            elsif (utility::parse_prop ($_, {})) { # NOP, just parse it
+            }
             elsif (m/^\s*<group>\s*$/i) {
                 $state = 'group';
             }
@@ -180,6 +184,8 @@ sub Parse ($\@)
             }
             elsif (m/^\s*<html>(.*)<\/html>\s*$/i) {
                 $build_info{HTML} = $1;
+            }
+            elsif (utility::parse_prop ($_, {})) { # NOP, just parse it
             }
             else {
                 print STDERR "Error: Unexpected in state <$state>: $_\n";


### PR DESCRIPTION
See https://github.com/DOCGroup/scoreboard/pull/8

These changes fix the parsing in the integrated page generator and try to make matrix.py more robust by inserting skipped tests when builds or test results cause an error instead of crashing.